### PR TITLE
Replcace jQuery with vanilla Javascript

### DIFF
--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -25,12 +25,12 @@
     "use strict";
 
     // Helper function for iterating over Arrays and NodeLists.
-    var forEach = function (nodeList, callback, scope) {
+    var forEach = function (list, callback, scope) {
         var i;
-        for (i = 0; i < nodeList.length; i += 1) {
-            callback.call(scope, nodeList[i], i);
+        for (i = 0; i < list.length; i += 1) {
+            callback.call(scope, list[i], i);
         }
-        return nodeList;
+        return list;
     };
 
     var GridForms = {
@@ -40,15 +40,23 @@
             focusableFields: []
         },
 
+        // init queries and caches the document for existing [data-row-span]
+        // and [data-field-span], focuses the first autofocus element, equalizes
+        // field heights, and registers event handlers for focus, click, and
+        // blur events.
         init: function () {
 
             // Cache form elements.
             this.el.fieldsRows = document.querySelectorAll("[data-row-span]");
             this.el.fieldsContainers = document.querySelectorAll("[data-field-span]");
-            this.el.focusableFields = document.querySelectorAll("[data-field-span] input, [data-field-span] textarea, [data-field-span] select");
+            this.el.focusableFields = document.querySelectorAll([
+                "[data-field-span] input",
+                "[data-field-span] textarea",
+                "[data-field-span] select"
+            ].join(", "));
 
             // Focus any autofocus inputs.
-            this.focusField(document.querySelector(".grid-form :focus"));
+            this.focusField(document.querySelector("[autofocus]"));
 
             // Adjust field heights.
             this.equalizeFieldHeights();
@@ -60,9 +68,10 @@
         // focusField finds the parent of the given HTMLElement (typically an
         // input) and appends the 'focus' class name to the element.
         focusField: function (currentField) {
-            if (currentField === null) {
+            if (!currentField) {
                 return;
             }
+
             var elem;
             var className = "focus";
             for (elem = currentField.parentNode; elem && elem !== document; elem = elem.parentNode) {
@@ -87,17 +96,13 @@
         // events initializes event listeners and handlers.
         events: function () {
             var that = this;
-            var inputs;
 
             forEach(this.el.fieldsContainers, function (el) {
 
                 // Listen to form field clicks to trigger focus on child focusable
                 // input elements.
                 el.addEventListener("click", function () {
-                    inputs = this.querySelectorAll("input, textarea, select");
-                    forEach(inputs, function (el) {
-                        el.focus();
-                    }, this);
+                    el.querySelector("input, textarea, select").focus();
                 });
             }, this);
 
@@ -137,7 +142,7 @@
                 forEach(this.el.fieldsRows, function (el) {
                     rowHeight = parseInt(window.getComputedStyle(el).height.slice(0, -2), 10);
                     forEach(el.querySelectorAll("[data-field-span]"), function (field) {
-                        field.style.height = rowHeight;
+                        field.style.height = rowHeight + "px";
                     }, this);
                 }, this);
             }
@@ -147,7 +152,7 @@
         // is greater than the width of its parent '[data-row-span]'.
         areFieldsStacked: function () {
             var firstRow = document.querySelector("[data-row-span]:not([data-row-span='1'])");
-            if (firstRow === null) {
+            if (!firstRow) {
                 return;
             }
 
@@ -166,9 +171,7 @@
         }
     };
 
-    document.addEventListener("DOMContentLoaded", function () {
-        GridForms.init();
-    });
+    document.addEventListener("DOMContentLoaded", GridForms.init.bind(GridForms));
 
     window.GridForms = GridForms;
 }());


### PR DESCRIPTION
Hi kumailht, I've used this library for a quick project at work and fell in love with the look. I got finished with the project so quickly that I had a whole day to fool around and work something up.

This PR removes the jQuery dependency for gridforms.js

Some notes: this is mostly untested on browsers besides Chrome and Firefox and all I can really say is that it definitely won't work in IE8 or lower. I guess that's why people use jQuery. Anyway, if you were so inclined to see jQuery gone, this is how it might look. I completely understand if older browser compatibility is a must!

The methods that probably aren't friendly with <IE8:

* document.querySelector
* document.querySelectorAll
* document.addEventListener
* window.getComputedStyle

I wouldn't even know where to start with writing shims for those.

Thought I'd shoot this to you anyway since you made me look good at work and I might use my fork for a side project where I don't want the burden of jQuery when I don't need it. If you want to see some things changed just let me know I'd be more than happy to. It could probably stand to get some additional error handling for exceptional cases.