### PR TITLE
Override styles when printing to ensure good output.

### DIFF
--- a/gridforms/gridforms.sass
+++ b/gridforms/gridforms.sass
@@ -126,6 +126,25 @@
             &:hover
                 background: lighten($field-focus-color, 5%)
                 cursor: text
+                
+    // Overide styles when printing to ensure good looking output.
+    @media print
+        [data-row-span]
+            display: table
+            height: 56px
+            page-break-inside: avoid
+
+            [data-field-span]
+                border-right: 1px solid #333333
+                display: table-cell
+                float: none
+         
+                &.focus,
+                &:hover
+                    background: none 
+
+                label:first-child
+                    letter-spacing: 0
 
     // Create row spans for n columns in the grid
     @for $grid_i from 1 through $max-columns


### PR DESCRIPTION
After **numerous** trials and errors with the help from @kumailht we finally were able to override some settings when printing GridForms to ensure the forms look as good on paper as they do on the screen.

To ensure these styles are activated (i.e. the media type is set to print) use the following in the wkhtmltopdf command line:

`--print-media-type`

If using `wicked_pdf` to generate PDFs in Rails, you can use `print_media_type: true` configuration option.