### PR TITLE
Improved input focusing when there are multiple fields

### DIFF
--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -42,8 +42,12 @@ $(function() {
         },
         events: function() {
             var that = this;
-            that.el.fieldsContainers.click(function() {
-                $(this).find('input[type="text"], textarea, select').focus();
+            that.el.fieldsContainers.click(function(event) {
+                var focusableFields = that.el.focusableFields.selector;
+                
+                if (!$(event.target).is(focusableFields)) {
+                    $(this).find('input[type="text"], textarea, select').first().focus();
+                }
             });
             that.el.focusableFields.focus(function() {
                 that.focusField($(this));


### PR DESCRIPTION
This improves focusing of inputs when clicking on field containers (see pull requests #10 and #14 for more information). Normal focusing functionality for singular inputs remains the same, but we can now support edge cases like datetime fields and multiple checkboxes/radios.

This change prevents switching input focus when the user clicks on an input. Because of this correction, we're now able to have multiple inputs in a container without focus being triggered on all of them. Along with this, if a user clicks on the field container (i.e. not an input), normal focus functionality will still focus on the first input of the container.