### PR TITLE
Add package.json for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gridforms",
+  "version": "1.0.0",
+  "description": "Data entry can be beautiful",
+  "files": [
+    "gridforms"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kumailht/gridforms.git"
+  },
+  "keywords": [
+    "responsive",
+    "grid",
+    "forms"
+  ],
+  "author": "Kumail Hunaid <contact@kumailht.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kumailht/gridforms/issues"
+  },
+  "homepage": "https://github.com/kumailht/gridforms#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridforms",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "Data entry can be beautiful",
   "files": [
     "gridforms"


### PR DESCRIPTION
I'm creating a React library which provides components for using gridforms - ideally I 'd like to have it installed from npm instead of having to vendor it myself.

With this package.json, you should be good to run `npm publish` from the project's root.

Thanks for making gridforms :+1: 