### PR TITLE
Support vertical textarea scaling

### DIFF
--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -72,6 +72,11 @@ $(function() {
                     // Get the height of the row (thus the tallest element's height)
                     var fieldRow = $(this);
                     var rowHeight = fieldRow.css('height');
+                    
+                    // Singleton textarea rows should determine their row height
+                    if (fieldRow.children().children("textarea").length === 1) {
+                      return;
+                    }
 
                     // Set the height for each field in the row...
                     fieldRow.find(fieldsContainers).css('height', rowHeight);

--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -74,9 +74,9 @@ $(function() {
                     var rowHeight = fieldRow.css('height');
                     
                     // Singleton textarea rows should determine their row height
-                    if (fieldRow.children().children("textarea").length === 1) {
-                      return;
-                    }
+                    var rowInputs = fieldRow.children();
+                    var textAreas = rowInputs.children("textarea");
+                    if (rowInputs.length === 1 && textAreas.length === 1) return;
 
                     // Set the height for each field in the row...
                     fieldRow.find(fieldsContainers).css('height', rowHeight);


### PR DESCRIPTION
This change provides support for vertical scaling on singleton textarea rows (see #24, which was closed without being fixed).

This change is accomplished by simply returning early before setting the height of the textarea's row. These rows will instead use the default `height: auto`. This intentionally doesn't support rows which textarea's share with other inputs, so that row heights remain consistent.