### PR TITLE
take only visible fieldRows into account when equalizing field heights

### DIFF
--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -68,7 +68,7 @@ $(function() {
 
             // Make sure that the fields aren't stacked
             if (!this.areFieldsStacked()) {
-                fieldsRows.each(function() {
+                fieldsRows.filter(":visible").each(function() {
                     // Get the height of the row (thus the tallest element's height)
                     var fieldRow = $(this);
                     var rowHeight = fieldRow.css('height');


### PR DESCRIPTION
when `equalizeFieldHeights()` runs while elements are not yet visible (e.g. hidden via `$(...).hide()` elements will be calculated with a height of 0px. Those fields will afterwards not show up again when calling `$(...).show()` on them, because they still have the height of 0px.