### PR TITLE
Perf optimize equalizeFieldHeights

### DIFF
--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -69,14 +69,14 @@ jQuery(function($) {
             // Make sure that the fields aren't stacked
             if (!this.areFieldsStacked()) {
                 fieldsRows.filter(":visible").each(function() {
-                    // Get the height of the row (thus the tallest element's height)
                     var fieldRow = $(this);
-                    var rowHeight = fieldRow.css('height');
                     
                     // Singleton textarea rows should determine their row height
                     var rowInputs = fieldRow.children();
-                    var textAreas = rowInputs.children("textarea");
-                    if (rowInputs.length === 1 && textAreas.length === 1) return;
+                    if (rowInputs.length === 1 && rowInputs.children("textarea").length === 1) return;
+
+                    // Get the height of the row (thus the tallest element's height)
+                    var rowHeight = fieldRow.css('height');
 
                     // Set the height for each field in the row...
                     fieldRow.find(fieldsContainers).css('height', rowHeight);


### PR DESCRIPTION
Defer DOM operations until really required.

DOM operations are slow, dont trigger them when you dont need it.