### PR TITLE
Fix #52: Remove deprecated jQuery .selector

### DIFF
--- a/gridforms/gridforms.js
+++ b/gridforms/gridforms.js
@@ -43,7 +43,7 @@ jQuery(function($) {
         events: function() {
             var that = this;
             that.el.fieldsContainers.click(function(event) {
-                var focusableFields = that.el.focusableFields.selector;
+                var focusableFields = that.el.focusableFields;
 
                 if (!$(event.target).is(focusableFields)) {
                     $(this).find('input[type="text"],input[type="number"],input[type="tel"],input[type="email"], textarea, select').first().focus();


### PR DESCRIPTION
The functionality still worked by removing the .selector
from that.el.focusableFields.